### PR TITLE
Upgrade to zod 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 - Bumped dependencies to resolve security advisories (`npm audit fix`).
-- Upgraded `vitest` to v4.
+- Upgraded `vitest` to v4 (test tooling now requires Node 20+).
+- Upgraded `zod` to v4. Object-level config defaults use `.prefault({})`
+  (zod 4's replacement for `.default({})` when relying on inner field defaults).
+- Bumped `actions/checkout` and `actions/setup-node` to v6 in CI.
 
 ## [0.1.0] - 2026-03
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,30 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT"
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "simple-git": "^3.27.0",
         "tree-sitter-wasms": "^0.1.13",
         "web-tree-sitter": "^0.24.7",
-        "zod": "^3.24.2"
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@types/node": "^22.13.10",
@@ -59,30 +59,6 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT"
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
@@ -4321,9 +4297,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "peer": true,
       "funding": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "simple-git": "^3.27.0",
     "tree-sitter-wasms": "^0.1.13",
     "web-tree-sitter": "^0.24.7",
-    "zod": "^3.24.2"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^22.13.10",

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -43,10 +43,14 @@ export const SearchConfigSchema = z.object({
 });
 
 export const ProjectConfigSchema = z.object({
-  embedding: EmbeddingConfigSchema.default({}),
-  files: FilesConfigSchema.default({}),
-  chunking: ChunkingConfigSchema.default({}),
-  search: SearchConfigSchema.default({}),
+  // zod 4: .prefault() parses the given value through the schema (applying each
+  // field's own default), whereas .default() now short-circuits and expects the
+  // full output object. We want an omitted section to become {} and then be
+  // filled in by the inner field defaults.
+  embedding: EmbeddingConfigSchema.prefault({}),
+  files: FilesConfigSchema.prefault({}),
+  chunking: ChunkingConfigSchema.prefault({}),
+  search: SearchConfigSchema.prefault({}),
 });
 
 export type EmbeddingConfig = z.infer<typeof EmbeddingConfigSchema>;


### PR DESCRIPTION
Migrates to zod 4 (supersedes Dependabot #6, which failed CI on the breaking change).

## Change
zod 4 redefined `.default()` to expect the **output** type and short-circuit parsing. The config schema used `.default({})` on object sections so that an omitted section would be filled in by its inner field defaults. zod 4's equivalent is `.prefault({})`, which parses the provided value through the schema.

- `src/config/schema.ts`: four `.default({})` → `.prefault({})`

## Verification
- `npm run build` clean
- `npm test` 17/17 pass
- Runtime check: `ProjectConfigSchema.parse({})` still yields full defaults
  (`provider: auto`, `gitOnly: true`, `maxChunkLines: 100`, `defaultLimit: 10`)
- `npm audit`: 0 vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)